### PR TITLE
エラーハンドル準備

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -32,6 +32,7 @@
     "import/prefer-default-export": "off",
     "jsx-quotes": "off",
     "prefer-destructuring": "off",
+    "import/no-cycle": "off",
     "no-param-reassign": ["error", { "props": false }],
     "import/order": [
       "error",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -32,6 +32,7 @@
     "import/prefer-default-export": "off",
     "jsx-quotes": "off",
     "prefer-destructuring": "off",
+    "no-param-reassign": ["error", { "props": false }],
     "import/order": [
       "error",
       {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "lodash": "^4.17.21",
     "normalize.css": "^8.0.1",
     "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react-dom": "^18.0.0",
+    "react-redux": "^8.0.1",
+    "@reduxjs/toolkit": "^1.8.1"
   },
   "devDependencies": {
     "@types/lodash": "^4.14.182",

--- a/src/@types/api.d.ts
+++ b/src/@types/api.d.ts
@@ -8,6 +8,12 @@ interface MicroCmsRequest {
   filters: string
   fields: string
 }
+export interface MicroCmsResponse<T> {
+  contents: T[]
+  totalCount: number
+  offset: number
+  limit: number
+}
 
 /*
  * Auth

--- a/src/@types/error.d.ts
+++ b/src/@types/error.d.ts
@@ -3,8 +3,6 @@ export interface ErrorResponse {
   errMsg: string
 }
 
-export type ErrorCodes = Record<string, ErrorResponse>
-
 export interface FirebaseError {
   code: string
   message: string

--- a/src/app/hooks.ts
+++ b/src/app/hooks.ts
@@ -1,0 +1,6 @@
+import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux'
+
+import type { RootState, AppDispatch } from './store'
+
+export const useAppDispatch = () => useDispatch<AppDispatch>()
+export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector

--- a/src/app/slices/toastSlice.ts
+++ b/src/app/slices/toastSlice.ts
@@ -1,0 +1,40 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+
+import { RootState } from '../store'
+
+export interface Toast {
+  isShow: boolean
+  type: 'success' | 'error' | 'warning' | 'info'
+  message: string
+}
+
+interface InitialState {
+  toast: Toast
+}
+
+const initialState: InitialState = {
+  toast: {
+    isShow: false,
+    type: 'success',
+    message: '',
+  },
+}
+
+export const toastSlice = createSlice({
+  name: 'toast',
+  initialState,
+  reducers: {
+    setToast: (state, action: PayloadAction<Toast>) => {
+      state.toast = action.payload
+    },
+    resetToast: (state) => {
+      state.toast = initialState.toast
+    },
+  },
+})
+
+export const { setToast, resetToast } = toastSlice.actions
+
+export const selectToast = (state: RootState) => state.toast
+
+export default toastSlice.reducer

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -1,0 +1,18 @@
+import { configureStore, ThunkAction, Action } from '@reduxjs/toolkit'
+
+import toastReducer from './slices/toastSlice'
+
+export const store = configureStore({
+  reducer: {
+    toast: toastReducer,
+  },
+})
+
+export type AppDispatch = typeof store.dispatch
+export type RootState = ReturnType<typeof store.getState>
+export type AppThunk<ReturnType = void> = ThunkAction<
+  ReturnType,
+  RootState,
+  unknown,
+  Action<string>
+>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,13 +1,17 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
+import { Provider } from 'react-redux'
 
+import App from './App'
+import { store } from './app/store'
 import 'normalize.css'
 import './styles/index.scss'
-import App from './App'
 
 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 ReactDOM.createRoot(document.getElementById('root')!).render(
   // <React.StrictMode>
-  <App />
+  <Provider store={store}>
+    <App />
+  </Provider>
   // </React.StrictMode>
 )

--- a/src/scripts/lib/error.ts
+++ b/src/scripts/lib/error.ts
@@ -1,6 +1,4 @@
-import { ErrorCodes } from '../../@types/error'
-
-export const ERROR_CODES: ErrorCodes = {
+export const ERROR_CODES = {
   /*
    * Response status 200番台
    */

--- a/src/scripts/lib/responseErrorHandler.ts
+++ b/src/scripts/lib/responseErrorHandler.ts
@@ -1,0 +1,16 @@
+import { AxiosResponse } from 'axios'
+import { isEmpty } from 'lodash'
+
+import { MicroCmsResponse } from '../../@types/api'
+import { ERROR_CODES } from './error'
+
+export const errorHandler = <T>(res: AxiosResponse<MicroCmsResponse<T>>) => {
+  if (isEmpty(res.data.contents)) {
+    return {
+      ...res.data,
+      errCode: ERROR_CODES.EMPTY_CONTENTS.errCode,
+      errMsg: ERROR_CODES.EMPTY_CONTENTS.errMsg,
+    }
+  }
+  return undefined
+}


### PR DESCRIPTION
### 実装
- トースト用のグローバルステート
- APIエラーハンドラー

### 詳細
- Reduxの追加
　- response以外のstateをグローバル管理 
- responseを参照して条件に満たない場合、エラーオブジェクトを返す
　- 現在、contentsがemptyの時だけ対応。今後増えていく可能性あり。 