### PR TITLE
ボタンコンポーネントのカスタマイズ

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^6.1.1",
+    "@fortawesome/free-brands-svg-icons": "^6.1.1",
     "@fortawesome/free-regular-svg-icons": "^6.1.1",
     "@fortawesome/free-solid-svg-icons": "^6.1.1",
     "@fortawesome/react-fontawesome": "^0.1.18",

--- a/src/components/atoms/PrimaryButton.tsx
+++ b/src/components/atoms/PrimaryButton.tsx
@@ -5,12 +5,24 @@ type Props = {
   onClick: () => void
   type?: 'button' | 'submit' | 'reset'
   isDisabled?: boolean
+  isRounded?: boolean
 }
 
 export const PrimaryButton: FC<Props> = (props: Props) => {
-  const { children, onClick, isDisabled = false, type = 'button' } = props
+  const {
+    children,
+    onClick,
+    isDisabled = false,
+    type = 'button',
+    isRounded = false,
+  } = props
   return (
-    <button className="btn" type={type} onClick={onClick} disabled={isDisabled}>
+    <button
+      className={`btn ${isRounded ? 'btn-rounded' : undefined}`}
+      type={type}
+      onClick={onClick}
+      disabled={isDisabled}
+    >
       {children}
     </button>
   )

--- a/src/components/templates/HeaderLayout.tsx
+++ b/src/components/templates/HeaderLayout.tsx
@@ -5,12 +5,14 @@ import { Link as RouterLink } from 'react-router-dom'
 
 import { useAppSelector } from '../../app/hooks'
 import { selectUser } from '../../app/slices/userSlice'
+import { useAuth } from '../../scripts/hooks/useAuth'
 import { APP_TITLE } from '../../scripts/utils/const'
 import { Avatar } from '../atoms/Avatar'
 import { PrimaryButton } from '../atoms/PrimaryButton'
 
 export const HeaderLayout = () => {
   const loginUser = useAppSelector(selectUser)
+  const { login } = useAuth()
 
   return (
     <header className="l-header">
@@ -24,8 +26,13 @@ export const HeaderLayout = () => {
           </RouterLink>
           <nav className="l-header_content-menu">
             {isEmpty(loginUser.user.userId) ? (
-              // TODO: login: モーダル開く addnew: 記事作成ページ遷移 avatar: menu表示
-              <PrimaryButton onClick={console.log}>Log in</PrimaryButton>
+              // TODO: addnew: 記事作成ページ遷移 avatar: menu表示
+              <PrimaryButton onClick={login} isRounded>
+                <p className="iconwithbtn">
+                  <FontAwesomeIcon icon={['fab', 'google']} />
+                  <span>Login with Google</span>
+                </p>
+              </PrimaryButton>
             ) : (
               <>
                 <Suspense fallback={<span>Loading...</span>}>

--- a/src/fontawesome.ts
+++ b/src/fontawesome.ts
@@ -1,4 +1,5 @@
 import { library } from '@fortawesome/fontawesome-svg-core'
+import { faGoogle } from '@fortawesome/free-brands-svg-icons'
 import {
   faCircleCheck,
   faCircleExclamation,
@@ -12,5 +13,6 @@ library.add(
   faCircleExclamation,
   faCircleInfo,
   faXmark,
-  faLightbulb
+  faLightbulb,
+  faGoogle
 )

--- a/src/styles/Object/Component/_c-button.scss
+++ b/src/styles/Object/Component/_c-button.scss
@@ -6,4 +6,8 @@
   border-radius: 0 50px 50px 0;
   color: va.$Text;
   box-shadow: 0px 2px 3px rgb(51 51 51 / 70%);
+
+  &-rounded {
+    border-radius: 50px;
+  }
 }

--- a/src/styles/Object/Utility/_u-text.scss
+++ b/src/styles/Object/Utility/_u-text.scss
@@ -2,3 +2,9 @@
   line-height: 35px;
   height: 40px;
 }
+
+.iconwithbtn {
+  display: flex;
+  align-items: flex-end;
+  gap: 1rem;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -643,6 +643,13 @@
   dependencies:
     "@fortawesome/fontawesome-common-types" "6.1.1"
 
+"@fortawesome/free-brands-svg-icons@^6.1.1":
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-6.1.1.tgz#3580961d4f42bd51dc171842402f23a18a5480b1"
+  integrity sha512-mFbI/czjBZ+paUtw5NPr2IXjun5KAC8eFqh1hnxowjA4mMZxWz4GCIksq6j9ZSa6Uxj9JhjjDVEd77p2LN2Blg==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "6.1.1"
+
 "@fortawesome/free-regular-svg-icons@^6.1.1":
   version "6.1.1"
   resolved "https://registry.yarnpkg.com/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-6.1.1.tgz#3f2f58262a839edf0643cbacee7a8a8230061c98"


### PR DESCRIPTION
### 実施内容
- ボタンがラウンドになるようpropsを追加
- Googleログインボタン追加
- 押下でGoogleログインモーダル表示