### PR TITLE
typesの修正

### DIFF
--- a/src/@types/api.d.ts
+++ b/src/@types/api.d.ts
@@ -31,9 +31,12 @@ export interface AuthGoogleLoginResponse extends ErrorResponse {
  * 記事取得
  */
 export interface GetArticlesRequest extends Partial<GetMicroCmsRequest> {}
-export interface GetArticlesResponse
-  extends GetMicroCmsResponse<ResponseArticle>,
-    ErrorResponse {}
+export interface GetArticlesResponse extends ErrorResponse {
+  contents: ResponseArticle[]
+  totalCount: number
+  offset: number
+  limit: number
+}
 
 /*
  * 記事投稿
@@ -63,9 +66,12 @@ export interface UpdateArticleResponse extends ErrorResponse {
  * ユーザー取得
  */
 export interface GetUsersRequest extends Partial<GetMicroCmsRequest> {}
-export interface GetUsersResponse
-  extends GetMicroCmsResponse<ResponseUser>,
-    ErrorResponse {}
+export interface GetUsersResponse extends ErrorResponse {
+  contents: ResponseUser[]
+  totalCount: number
+  offset: number
+  limit: number
+}
 
 /*
  * ユーザー作成

--- a/src/@types/api.d.ts
+++ b/src/@types/api.d.ts
@@ -4,22 +4,6 @@ import { ResponseArticle } from './article'
 import { ErrorResponse } from './error'
 import { ResponseUser } from './user'
 
-interface GetMicroCmsRequest {
-  offset: number
-  limit: number
-  filters: string
-  fields: string
-}
-export interface GetMicroCmsResponse<T> {
-  contents: T[]
-  totalCount: number
-  offset: number
-  limit: number
-}
-export interface ExceptingGetMicroCmsResponse {
-  id: string
-}
-
 /*
  * Googleログイン
  */

--- a/src/@types/article.d.ts
+++ b/src/@types/article.d.ts
@@ -1,5 +1,3 @@
-import { CmsResponseDefault } from './cms.d'
-
 export interface Article {
   imageUrl: string
   title: string
@@ -8,4 +6,15 @@ export interface Article {
   contentCount: number
 }
 
-export interface ResponseArticle extends CmsResponseDefault, Article {}
+export interface ResponseArticle {
+  imageUrl: string
+  title: string
+  userId: string
+  content: string
+  contentCount: number
+  id: string
+  createdAt: string
+  updatedAt: string
+  publishedAt: string
+  revisedAt: string
+}

--- a/src/@types/cms.d.ts
+++ b/src/@types/cms.d.ts
@@ -1,7 +1,0 @@
-export interface CmsResponseDefault {
-  id: string
-  createdAt: string
-  updatedAt: string
-  publishedAt: string
-  revisedAt: string
-}

--- a/src/@types/cms.d.ts
+++ b/src/@types/cms.d.ts
@@ -1,0 +1,15 @@
+export interface GetMicroCmsRequest {
+  offset: number
+  limit: number
+  filters: string
+  fields: string
+}
+export interface GetMicroCmsResponse<T> {
+  contents: T[]
+  totalCount: number
+  offset: number
+  limit: number
+}
+export interface ExceptingGetMicroCmsResponse {
+  id: string
+}

--- a/src/@types/user.d.ts
+++ b/src/@types/user.d.ts
@@ -1,5 +1,3 @@
-import { CmsResponseDefault } from './cms.d'
-
 export interface User {
   name: string
   photoURL: string
@@ -9,4 +7,16 @@ export interface User {
   userId: string
 }
 
-export interface ResponseUser extends CmsResponseDefault, User {}
+export interface ResponseUser {
+  name: string
+  photoURL: string
+  description?: string
+  twitterUrl?: string
+  facebookUrl?: string
+  userId: string
+  id: string
+  createdAt: string
+  updatedAt: string
+  publishedAt: string
+  revisedAt: string
+}

--- a/src/scripts/lib/api.ts
+++ b/src/scripts/lib/api.ts
@@ -1,9 +1,7 @@
 import { isNil, omit } from 'lodash'
 
 import {
-  GetMicroCmsResponse,
   GetArticlesRequest,
-  ExceptingGetMicroCmsResponse,
   CreateArticleRequest,
   UpdateArticleRequest,
   GetArticlesResponse,
@@ -16,8 +14,7 @@ import {
   CreateUserResponse,
   UpdateUserResponse,
 } from '../../@types/api'
-import { ResponseArticle } from '../../@types/article'
-import { ResponseUser } from '../../@types/user.d'
+import { ExceptingGetMicroCmsResponse } from '../../@types/cms.d'
 import apiInstance from './axios'
 import { ERROR_CODES } from './error'
 import { errorHandler } from './responseErrorHandler'
@@ -46,12 +43,9 @@ export const fetchArticles = async (
   params?: GetArticlesRequest
 ): Promise<GetArticlesResponse> => {
   try {
-    const res = await apiInstance.get<GetMicroCmsResponse<ResponseArticle>>(
-      'articles',
-      {
-        params,
-      }
-    )
+    const res = await apiInstance.get<GetArticlesResponse>('articles', {
+      params,
+    })
     const validated = errorHandler(res)
     if (!isNil(validated)) {
       return validated
@@ -116,12 +110,9 @@ export const fetchUsers = async (
   params?: GetUsersRequest
 ): Promise<GetUsersResponse> => {
   try {
-    const res = await apiInstance.get<GetMicroCmsResponse<ResponseUser>>(
-      'users',
-      {
-        params,
-      }
-    )
+    const res = await apiInstance.get<GetUsersResponse>('users', {
+      params,
+    })
     const validated = errorHandler(res)
     if (!isNil(validated)) {
       return validated


### PR DESCRIPTION
### 実施内容
- responseの継承をエラーレスポンスのみに修正

### 実施理由
- 継承しすぎてわかりにくい為