### PR TITLE
検索フォームの修正

### DIFF
--- a/src/components/organisms/SearchForm.tsx
+++ b/src/components/organisms/SearchForm.tsx
@@ -8,7 +8,7 @@ type Input = {
   searchInput: string
 }
 
-export const SearchInput: FC = memo(() => {
+export const SearchForm: FC = memo(() => {
   const {
     register,
     formState: { errors },
@@ -23,17 +23,15 @@ export const SearchInput: FC = memo(() => {
           }
         />
       )}
-      <label className="c-form search-label" htmlFor="search">
+      <form className="c-form search-label">
         <input
           className="c-form-search"
           {...register('searchInput', { maxLength: 256 })}
         />
-        <FontAwesomeIcon
-          size="lg"
-          icon={['fas', 'magnifying-glass']}
-          className="c-form-search-icon"
-        />
-      </label>
+        <button type="submit" className="c-form-search-icon">
+          <FontAwesomeIcon size="lg" icon={['fas', 'magnifying-glass']} />
+        </button>
+      </form>
     </>
   )
 })

--- a/src/components/organisms/SearchForm.tsx
+++ b/src/components/organisms/SearchForm.tsx
@@ -1,6 +1,6 @@
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { FC, memo } from 'react'
-import { useForm } from 'react-hook-form'
+import { useForm, SubmitHandler } from 'react-hook-form'
 
 import { ErrorMessage } from '../atoms/ErrorMessage'
 
@@ -12,7 +12,12 @@ export const SearchForm: FC = memo(() => {
   const {
     register,
     formState: { errors },
+    handleSubmit,
   } = useForm<Input>()
+
+  const onSubmitForm: SubmitHandler<Input> = (data: Input) =>
+    // eslint-disable-next-line no-console
+    console.log('data', data.searchInput)
 
   return (
     <>
@@ -23,7 +28,10 @@ export const SearchForm: FC = memo(() => {
           }
         />
       )}
-      <form className="c-form search-label">
+      <form
+        onSubmit={handleSubmit(onSubmitForm)}
+        className="c-form search-label"
+      >
         <input
           className="c-form-search"
           {...register('searchInput', { maxLength: 256 })}

--- a/src/components/pages/ArticleList.tsx
+++ b/src/components/pages/ArticleList.tsx
@@ -8,7 +8,7 @@ import { formatArticleCards } from '../../scripts/utils/view'
 import { Loading } from '../atoms/Loading'
 import { SectionTitle } from '../atoms/SectionTitle'
 import { ArticleCard } from '../organisms/ArticleCard'
-import { SearchInput } from '../organisms/SearchInput'
+import { SearchForm } from '../organisms/SearchForm'
 import { ArticleContentsWrapper } from '../templates/ArticleContentsWrapper'
 import { SectionLayout } from '../templates/SectionLayout'
 
@@ -36,7 +36,7 @@ export const ArticleList = () => {
     <>
       <SectionLayout sectionName="article">
         <div className="p-section_content">
-          <SearchInput />
+          <SearchForm />
           <SectionTitle>Articles</SectionTitle>
           <ArticleContentsWrapper>
             {isNil(articleData) ? (

--- a/src/styles/Object/Component/_c-form.scss
+++ b/src/styles/Object/Component/_c-form.scss
@@ -17,22 +17,28 @@
   padding: 8px 15px;
   color: va.$Base;
   font-size: va.$Sentence;
+  transition: all 0.2s;
 
   &:focus {
-    border: 1px solid va.$FocusForm;
     box-shadow: 0 0 0 2.5px va.$FocusForm;
+
+    & + button {
+      transition: all 0.25s;
+      color: va.$FocusForm;
+    }
   }
 }
 
 .c-form {
   @extend .flex-column;
 
-  & > label {
-    @extend .base-label-style;
-  }
-
   &.search-label {
     position: relative;
+    transition: 0.2s;
+  }
+
+  & > label {
+    @extend .base-label-style;
   }
 
   & > input {


### PR DESCRIPTION
### 実施内容
- 検索フォームの構造を変更
　- label要素を排除してform要素を追加
　- アイコンをsubmitボタンでラップ
- formのonSubmitイベントの追加

### 実施理由
- 検索バーのみで検索処理を完結させる必要があったためイベントの発火までフォームで行うよう修正 