### PR TITLE
記事詳細画面の修正

### DIFF
--- a/src/@types/api.d.ts
+++ b/src/@types/api.d.ts
@@ -25,7 +25,7 @@ export interface GetImageUrlResponse extends ErrorResponse {
 }
 
 /*
- * 記事取得
+ * 記事一覧取得
  */
 export interface GetArticlesRequest extends Partial<GetMicroCmsRequest> {}
 export interface GetArticlesResponse extends ErrorResponse {
@@ -34,6 +34,16 @@ export interface GetArticlesResponse extends ErrorResponse {
   offset: number
   limit: number
 }
+
+/*
+ * 記事詳細取得
+ */
+export interface GetDetailArticleRequest {
+  id: string
+}
+export interface GetDetailArticleResponse
+  extends ResponseArticle,
+    ErrorResponse {}
 
 /*
  * 記事投稿

--- a/src/components/pages/ArticleDetail.tsx
+++ b/src/components/pages/ArticleDetail.tsx
@@ -1,5 +1,5 @@
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { isNil } from 'lodash'
+import { isEmpty, isNil } from 'lodash'
 import { useCallback } from 'react'
 import { useParams, Link } from 'react-router-dom'
 
@@ -24,14 +24,16 @@ export const ArticleDetail = () => {
    * Hooks
    */
   const params = useParams<{ id: string }>()
+  console.log(params.id)
   const { user: loginUser } = useAppSelector(selectUser)
   const { data: articlesData, isLoading: articleIsLoading } = useQueryArticles({
-    filter: `id[equals]${params.id}`,
+    id: params.id,
   })
   const { data: usersData, isLoading: userIsLoading } = useQueryUsers({
-    filter: isNil(articlesData)
-      ? undefined
-      : `userId[equals]${articlesData.contents[0].userId}`,
+    filter:
+      isNil(articlesData) || isEmpty(articlesData)
+        ? undefined
+        : `userId[equals]${articlesData.userId || ''}`,
   })
 
   const isError = useCallback(
@@ -65,9 +67,9 @@ export const ArticleDetail = () => {
           ) : (
             <>
               <DetailHeader
-                thumbSrc={articlesData.contents[0].thumbUrl || 'noimage.JPG'}
-                thumbAlt={articlesData.contents[0].title}
-                title={articlesData.contents[0].title}
+                thumbSrc={articlesData.thumbUrl || 'noimage.JPG'}
+                thumbAlt={articlesData.title}
+                title={articlesData.title}
               />
               <DetailContentWrapper>
                 <div className="p-section-article-detail_reaction">
@@ -82,9 +84,7 @@ export const ArticleDetail = () => {
                   </div>
                 </div>
                 <div className="p-section-article-detail_body u-glass">
-                  <PreviewMarkdown
-                    markdown={articlesData.contents[0].content}
-                  />
+                  <PreviewMarkdown markdown={articlesData.content} />
                 </div>
                 <aside className="p-section-article-detail_side">
                   <dl className="p-section-article-detail_side description u-glass">
@@ -109,9 +109,7 @@ export const ArticleDetail = () => {
                         />
                         公開日
                       </dt>
-                      <dd>
-                        {calculateDate(articlesData.contents[0].createdAt)}
-                      </dd>
+                      <dd>{calculateDate(articlesData.createdAt)}</dd>
                     </div>
                     <div>
                       <dt>
@@ -121,9 +119,7 @@ export const ArticleDetail = () => {
                         />
                         文章量
                       </dt>
-                      <dd>
-                        {stringCountFormatBy(articlesData.contents[0].content)}
-                      </dd>
+                      <dd>{stringCountFormatBy(articlesData.content)}</dd>
                     </div>
                   </dl>
                   <div className="p-section-article-detail_side follow u-glass">
@@ -138,7 +134,7 @@ export const ArticleDetail = () => {
                       {loginUser.userId === usersData.contents[0].userId ? (
                         <RouterLink
                           isBtn
-                          to={`/article/${articlesData.contents[0].id}/edit`}
+                          to={`/article/${articlesData.id}/edit`}
                         >
                           Edit
                         </RouterLink>

--- a/src/components/pages/ArticleDetail.tsx
+++ b/src/components/pages/ArticleDetail.tsx
@@ -1,11 +1,11 @@
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { isEmpty, isNil } from 'lodash'
+import { isNil } from 'lodash'
 import { useCallback } from 'react'
 import { useParams, Link } from 'react-router-dom'
 
 import { useAppSelector } from '../../app/hooks'
 import { selectUser } from '../../app/slices/userSlice'
-import { useQueryArticles } from '../../scripts/hooks/useQueryArticles'
+import { useQueryDetailArticle } from '../../scripts/hooks/useQueryDetailArticle'
 import { useQueryUsers } from '../../scripts/hooks/useQueryUsers'
 import { ERROR_CODES } from '../../scripts/lib/error'
 import { calculateDate } from '../../scripts/utils/dateFormat'
@@ -24,36 +24,33 @@ export const ArticleDetail = () => {
    * Hooks
    */
   const params = useParams<{ id: string }>()
-  console.log(params.id)
   const { user: loginUser } = useAppSelector(selectUser)
-  const { data: articlesData, isLoading: articleIsLoading } = useQueryArticles({
-    id: params.id,
-  })
+  const { data: articleData, isLoading: articleIsLoading } =
+    useQueryDetailArticle({ articleId: params.id || '' })
   const { data: usersData, isLoading: userIsLoading } = useQueryUsers({
-    filter:
-      isNil(articlesData) || isEmpty(articlesData)
-        ? undefined
-        : `userId[equals]${articlesData.userId || ''}`,
+    filter: isNil(articleData)
+      ? undefined
+      : `userId[equals]${articleData.userId || ''}`,
   })
 
   const isError = useCallback(
     () =>
-      articlesData?.errCode !== ERROR_CODES.NORMAL_NOOP.errCode ||
+      articleData?.errCode !== ERROR_CODES.NORMAL_NOOP.errCode ||
       usersData?.errCode !== ERROR_CODES.NORMAL_NOOP.errCode,
-    [articlesData, usersData]
+    [articleData, usersData]
   )
 
   const renderError = useCallback(
     () => (
       <ErrorMessage>
-        {articlesData?.errMsg
-          ? articlesData.errMsg
+        {articleData?.errMsg
+          ? articleData.errMsg
           : usersData?.errMsg
           ? usersData.errMsg
           : ERROR_CODES.UNKNOWN_ERROR.errMsg}
       </ErrorMessage>
     ),
-    [articlesData, usersData]
+    [articleData, usersData]
   )
 
   return (
@@ -62,14 +59,14 @@ export const ArticleDetail = () => {
         <Loading />
       ) : (
         <div>
-          {isNil(articlesData) || isNil(usersData) || isError() ? (
+          {isNil(articleData) || isNil(usersData) || isError() ? (
             renderError()
           ) : (
             <>
               <DetailHeader
-                thumbSrc={articlesData.thumbUrl || 'noimage.JPG'}
-                thumbAlt={articlesData.title}
-                title={articlesData.title}
+                thumbSrc={articleData.thumbUrl || 'noimage.JPG'}
+                thumbAlt={articleData.title}
+                title={articleData.title}
               />
               <DetailContentWrapper>
                 <div className="p-section-article-detail_reaction">
@@ -84,7 +81,7 @@ export const ArticleDetail = () => {
                   </div>
                 </div>
                 <div className="p-section-article-detail_body u-glass">
-                  <PreviewMarkdown markdown={articlesData.content} />
+                  <PreviewMarkdown markdown={articleData.content} />
                 </div>
                 <aside className="p-section-article-detail_side">
                   <dl className="p-section-article-detail_side description u-glass">
@@ -109,7 +106,7 @@ export const ArticleDetail = () => {
                         />
                         公開日
                       </dt>
-                      <dd>{calculateDate(articlesData.createdAt)}</dd>
+                      <dd>{calculateDate(articleData.createdAt)}</dd>
                     </div>
                     <div>
                       <dt>
@@ -119,7 +116,7 @@ export const ArticleDetail = () => {
                         />
                         文章量
                       </dt>
-                      <dd>{stringCountFormatBy(articlesData.content)}</dd>
+                      <dd>{stringCountFormatBy(articleData.content)}</dd>
                     </div>
                   </dl>
                   <div className="p-section-article-detail_side follow u-glass">
@@ -134,7 +131,7 @@ export const ArticleDetail = () => {
                       {loginUser.userId === usersData.contents[0].userId ? (
                         <RouterLink
                           isBtn
-                          to={`/article/${articlesData.id}/edit`}
+                          to={`/article/${articleData.id}/edit`}
                         >
                           Edit
                         </RouterLink>

--- a/src/scripts/hooks/useQueryDetailArticle.ts
+++ b/src/scripts/hooks/useQueryDetailArticle.ts
@@ -1,0 +1,22 @@
+import { useQuery } from 'react-query'
+
+import { GetDetailArticleResponse } from '../../@types/api.d'
+import { fetchDetailArticle } from '../lib/api'
+import {
+  ARTICLE_DETAIL_STILE_TIME,
+  CACHE_KEY_ARTICLE_DETAIL,
+} from '../utils/const'
+
+type Props = {
+  articleId: string
+}
+
+export const useQueryDetailArticle = ({ articleId }: Props) =>
+  useQuery<GetDetailArticleResponse>({
+    queryKey: CACHE_KEY_ARTICLE_DETAIL,
+    queryFn: () =>
+      fetchDetailArticle({
+        id: articleId,
+      }),
+    staleTime: ARTICLE_DETAIL_STILE_TIME,
+  })

--- a/src/scripts/lib/api.ts
+++ b/src/scripts/lib/api.ts
@@ -13,6 +13,8 @@ import {
   GetUsersResponse,
   CreateUserResponse,
   UpdateUserResponse,
+  GetDetailArticleRequest,
+  GetDetailArticleResponse,
 } from '../../@types/api'
 import { ExceptingGetMicroCmsResponse } from '../../@types/cms.d'
 import apiInstance from './axios'
@@ -22,7 +24,7 @@ import { errorHandler } from './responseErrorHandler'
 /*
 ? catch時に返す
  */
-const CATCH_RESPONSE_GET = {
+const CATCH_LIST_RESPONSE_GET = {
   contents: [],
   totalCount: 0,
   offset: 0,
@@ -56,7 +58,43 @@ export const fetchArticles = async (
       errMsg: ERROR_CODES.NORMAL_NOOP.errMsg,
     }
   } catch (e) {
-    return CATCH_RESPONSE_GET
+    return CATCH_LIST_RESPONSE_GET
+  }
+}
+
+/*
+ * 記事詳細取得
+ */
+export const fetchDetailArticle = async (
+  params: GetDetailArticleRequest
+): Promise<GetDetailArticleResponse> => {
+  try {
+    const res = await apiInstance.get<GetDetailArticleResponse>(
+      `articles/${params.id}`
+    )
+    const validated = errorHandler(res)
+    if (!isNil(validated)) {
+      return validated
+    }
+    return {
+      ...res.data,
+      errCode: ERROR_CODES.NORMAL_NOOP.errCode,
+      errMsg: ERROR_CODES.NORMAL_NOOP.errMsg,
+    }
+  } catch (e) {
+    return {
+      thumbUrl: '',
+      title: '',
+      userId: '',
+      content: '',
+      id: '',
+      createdAt: '',
+      updatedAt: '',
+      publishedAt: '',
+      revisedAt: '',
+      errCode: ERROR_CODES.INTERNAL_SERVER_ERROR.errCode,
+      errMsg: ERROR_CODES.INTERNAL_SERVER_ERROR.errMsg,
+    }
   }
 }
 
@@ -123,7 +161,7 @@ export const fetchUsers = async (
       errMsg: ERROR_CODES.NORMAL_NOOP.errMsg,
     }
   } catch (e) {
-    return CATCH_RESPONSE_GET
+    return CATCH_LIST_RESPONSE_GET
   }
 }
 

--- a/src/scripts/lib/responseErrorHandler.ts
+++ b/src/scripts/lib/responseErrorHandler.ts
@@ -1,11 +1,13 @@
 import { AxiosResponse } from 'axios'
 import { isEmpty } from 'lodash'
 
-import { GetMicroCmsResponse } from '../../@types/cms'
 import { ERROR_CODES } from './error'
 
-export const errorHandler = <T>(res: AxiosResponse<GetMicroCmsResponse<T>>) => {
-  if (isEmpty(res.data.contents)) {
+export const errorHandler = (res: AxiosResponse<any>) => {
+  if (
+    isEmpty(res.data) ||
+    ('contents' in res.data && isEmpty(res.data.contents))
+  ) {
     return {
       ...res.data,
       errCode: ERROR_CODES.EMPTY_CONTENTS.errCode,

--- a/src/scripts/utils/const.ts
+++ b/src/scripts/utils/const.ts
@@ -30,9 +30,11 @@ export const APP_TITLE = 'EI-EI-EIGHT'
  */
 export const PER_PAGE = 10
 export const TOAST_DURATION_TIME = 8000
+export const ARTICLE_DETAIL_STILE_TIME = 0
 
 /*
  * useQuery cache key
  */
 export const CACHE_KEY_ARTICLE = 'articles'
+export const CACHE_KEY_ARTICLE_DETAIL = 'article_detail'
 export const CACHE_KEY_USER = 'users'


### PR DESCRIPTION
### 実施内容
- 記事詳細画面が真っ白になる原因を修正
- クエリパラメーターによってうまく記事詳細が取得できていなかったため、記事詳細用のAPIを用意して対応